### PR TITLE
use static hashmap to collect requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,15 @@ publish = false
 
 [dependencies]
 actix = "0.5.8"
+antidote = "1.0.0"
 crossbeam-channel = "0.2.2"
 futures = "0.1.21"
+lazy_static = "1.0.2"
+rand = "0.5.4"
 
 [dependencies.actix-web]
 version = "0.6.15"
 default-features = false
 
 [dev-dependencies]
-rand = "0.5.4"
 reqwest = "0.8.6"


### PR DESCRIPTION
- use random int to seperate requests per test-server instance
- closes #4